### PR TITLE
annotate.tpl.html: avoid this.remove(): it crashes IE

### DIFF
--- a/registry/html/annotate.tpl.html
+++ b/registry/html/annotate.tpl.html
@@ -90,7 +90,7 @@ jQuery(document).ready(function () {
                 .css("width", jQuery(window).width())
                 .fadeIn("fast");
             jQuery("#preview").click(function () {
-                this.remove();
+                jQuery(this).replaceWith("");  /* XXX */
             });
         }, function() {
             // nothing to do
@@ -100,7 +100,7 @@ jQuery(document).ready(function () {
         jQuery("iframe").each(function () {
             if (this.src.indexOf("https://www.youtube.com", 0) !== 0 &&
                     this.src.indexOf("http://www.youtube.com", 0) !== 0) {
-                this.remove();
+                jQuery(this).replaceWith("");  /* XXX */
                 return;
             }
             if (this.src.indexOf("http://", 0) === 0) {


### PR DESCRIPTION
Under IE 10, this.remove() raises an exception which is not handled and stops the JavaScript interpreter.

Waiting for a more comprehensive groking of JavaScript, use a hack to circumvent the problem with IE: replace the DOM object to be replaced with an empty string.

Tested on IE 10, Firefox 30.0 and Chromium 34.
