### PR TITLE
init_iptables.sh: Close port 4443

### DIFF
--- a/registry/init_iptables.sh
+++ b/registry/init_iptables.sh
@@ -35,6 +35,9 @@ SUDO=/usr/bin/sudo
 $SUDO $IPTABLES -t mangle -A PREROUTING -p tcp --dport 8080 \
     -j MARK --set-mark 1
 
+$SUDO $IPTABLES -t mangle -A PREROUTING -p tcp --dport 4443 \
+    -j MARK --set-mark 1
+
 $SUDO $IPTABLES -t nat -A PREROUTING -p tcp --dport 443 \
     -j REDIRECT --to-port 4443
 


### PR DESCRIPTION
As requested by the Politecnico di Torino network-security staff, port 4443 is now closed, and students can only use 443.

We can safely do this, now that the course is ended (i.e., no one is going to complain about 4443 being now closed).

Tested this diff by deploying it on highgarden: no issues, except that 4443 is now unreachable.
