### PR TITLE
setup.sh: set permissions to passwd file when created

### DIFF
--- a/registry/setup.sh
+++ b/registry/setup.sh
@@ -105,6 +105,7 @@ if [ ! -d $DATADIR ]; then
         cd $DATADIR
         git init
         echo "{}" > .htpasswd
+        chmod 640 .htpasswd
         git add .htpasswd
         git config user.name "Root"
         git config user.email "root@localhost"


### PR DESCRIPTION
Fixing #104 
I find out that in setup.sh we haven't specified any permissions for .htpasswd, so everyone could read. I also fixed permissions in the current ongoing file.
I think that all /etc/rivoluz files are well restricted. Instead we have no so strong permissions in /var/lib/rivoluz where many files can be read by everyone. IMHO it's not a problem because apart from passwords, all other informations are quite public. So I decided to fix only .htpasswd permissions.
