### PR TITLE
Rewrite ghost var

### DIFF
--- a/registry/backend.js
+++ b/registry/backend.js
@@ -37,6 +37,7 @@ var utils = require("./utils");
 
 var MATRICOLA = /^[0-9]{6}$/;
 var TOKEN = /^[A-Fa-f0-9]{40}$/;
+var MAYBE_EMPTY_TOKEN = /^(|[A-Fa-f0-9]{40})$/;
 var PWDHASH = /^[A-Fa-f0-9]{32}$/;
 var URL = /^(|http(|s)\:\/\/[A-Za-z0-9\.\-\_\%\?\&\=\/]+)$/;
 


### PR DESCRIPTION
Something wrong occurred in last merge:
- https://github.com/bassosimone/rivoluzionedigitale/commit/4295394a9fcb398d05f5468434ff50ddf487bc7a here I removed MAYBE_EMPTY_TOKEN for error;
- https://github.com/bassosimone/rivoluzionedigitale/commit/d8a19db5edd5b9ca472b946b36298f71523ba238 in fact in the following commit I restore it.

But when you merge all commits, that var disappeared.
